### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "lifesciences",
     "name_pretty": "Cloud Life Sciences",
     "product_documentation": "https://cloud.google.com/life-sciences/",
-    "client_documentation": "https://googleapis.dev/python/lifesciences/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/lifesciences/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Life Sciences API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-life-sciences.svg
    :target: https://pypi.org/project/google-cloud-life-sciences/
 .. _Cloud Life Sciences: https://cloud.google.com/life-sciences/
-.. _Client Library Documentation: https://googleapis.dev/python/lifesciences/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/lifesciences/latest
 .. _Product Documentation:  https://cloud.google.com/life-sciences/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.